### PR TITLE
Odometry floor collision

### DIFF
--- a/multirotor_simulator/imu_simulator/inertial_odometry.hpp
+++ b/multirotor_simulator/imu_simulator/inertial_odometry.hpp
@@ -92,7 +92,8 @@ public:
   InertialOdometry(Scalar alpha                         = 1.0,
                    Quaternion initial_world_orientation = Quaternion::Identity(),
                    Vector3 initial_world_position       = Vector3::Zero())
-      : alpha_(alpha), initial_world_orientation_(initial_world_orientation) {
+      : alpha_(alpha), initial_world_orientation_(initial_world_orientation),
+        initial_world_position_(initial_world_position) {
     assert(alpha_ > 0 && alpha_ <= 1);
     reset();
   }
@@ -103,7 +104,9 @@ public:
    * @param params Inertial Odometry parameters
    */
   explicit InertialOdometry(const InertialOdometryParams<Precision>& params)
-      : InertialOdometry(params.alpha, params.initial_world_orientation) {}
+      : InertialOdometry(params.alpha,
+                         params.initial_world_orientation,
+                         params.initial_world_position) {}
 
   ~InertialOdometry() {}
 
@@ -122,7 +125,9 @@ public:
    *
    * @param initial_position Initial position in world frame
    */
-  void set_initial_position(const Vector3& initial_position) { position_ = initial_position; }
+  void set_initial_position(const Vector3& initial_position) {
+    initial_world_position_ = initial_position;
+  }
 
   /**
    * @brief Reset the inertial odometry
@@ -137,6 +142,7 @@ public:
     position_            = initial_world_position_;
     orientation_         = initial_world_orientation_;
   }
+
   /**
    * @brief Update the inertial odometry with a new measurement
    *

--- a/multirotor_simulator/imu_simulator/inertial_odometry.hpp
+++ b/multirotor_simulator/imu_simulator/inertial_odometry.hpp
@@ -63,6 +63,7 @@ struct InertialOdometryParams {
 
   // Initial orientation
   Eigen::Quaternion<P> initial_world_orientation = Eigen::Quaternion<P>::Identity();
+  Eigen::Vector3<P> initial_world_position       = Eigen::Vector3<P>::Zero();
 };
 
 /**
@@ -86,9 +87,11 @@ public:
    *
    * @param alpha Filter parameter (0 < alpha < 1, 1: no filter)
    * @param initial_world_orientation Initial orientation in world frame
+   * @param initial_world_position Initial position in world frame
    */
   InertialOdometry(Scalar alpha                         = 1.0,
-                   Quaternion initial_world_orientation = Quaternion::Identity())
+                   Quaternion initial_world_orientation = Quaternion::Identity(),
+                   Vector3 initial_world_position       = Vector3::Zero())
       : alpha_(alpha), initial_world_orientation_(initial_world_orientation) {
     assert(alpha_ > 0 && alpha_ <= 1);
     reset();
@@ -115,6 +118,13 @@ public:
   }
 
   /**
+   * @brief Set the initial position in world frame
+   *
+   * @param initial_position Initial position in world frame
+   */
+  void set_initial_position(const Vector3& initial_position) { position_ = initial_position; }
+
+  /**
    * @brief Reset the inertial odometry
    *
    */
@@ -123,8 +133,8 @@ public:
     accel_filtered_      = Vector3::Zero();
     linear_acceleration_ = Vector3::Zero();
     linear_velocity_     = Vector3::Zero();
-    position_            = Vector3::Zero();
     angular_velocity_    = Vector3::Zero();
+    position_            = initial_world_position_;
     orientation_         = initial_world_orientation_;
   }
   /**
@@ -198,6 +208,7 @@ public:
 protected:
   // Filter
   Scalar alpha_                         = 0.1;
+  Vector3 initial_world_position_       = Vector3::Zero();
   Quaternion initial_world_orientation_ = Quaternion::Identity();
 
   // Measurement in body frame

--- a/multirotor_simulator/multirotor_simulator.hpp
+++ b/multirotor_simulator/multirotor_simulator.hpp
@@ -103,6 +103,7 @@ class Simulator {
   using Scalar     = Precision;
   using Vector3    = Eigen::Matrix<Precision, 3, 1>;
   using VectorN    = Eigen::Matrix<Precision, num_rotors, 1>;
+  using Quaternion = Eigen::Quaternion<Precision>;
   using Kinematics = state::internal::Kinematics<Precision>;
 
   // Dynamics
@@ -158,11 +159,18 @@ public:
       state.actuators = dynamics_.get_state().actuators;
       dynamics_.set_state(state);
 
+      // Reset odometry
+
       // Reset IMU
       imu_.reset();
 
       // Reset Inertial Odometry
-      inertial_odometry_.set_initial_orientation(dynamics_.get_state().kinematics.orientation);
+      Vector3 position       = inertial_odometry_.get_position();
+      position.z()           = floor_height_;
+      Quaternion orientation = inertial_odometry_.get_orientation();
+
+      inertial_odometry_.set_initial_position(position);
+      inertial_odometry_.set_initial_orientation(orientation);
       inertial_odometry_.reset();
     }
   }


### PR DESCRIPTION
When dron land, do not reset odometry to world origin, just keep the odometry position and orientation.